### PR TITLE
Added BeaconCore dependencies

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,42 @@
 PODS:
+  - Base58Swift (2.1.10):
+    - BigInt (~> 5.0.0)
+  - BeaconBlockchainSubstrate (3.1.0):
+    - BeaconCore (~> 3.1.0)
+  - BeaconBlockchainTezos (3.1.0):
+    - BeaconCore (~> 3.1.0)
+  - BeaconClientWallet (3.1.0):
+    - BeaconCore (~> 3.1.0)
+  - BeaconCore (3.1.0):
+    - Base58Swift (~> 2.1.0)
+    - Sodium (~> 0.9.1)
   - beacondart (0.0.1):
+    - BeaconBlockchainSubstrate
+    - BeaconBlockchainTezos
+    - BeaconClientWallet
+    - BeaconCore
+    - BeaconTransportP2PMatrix
     - Flutter
+  - BeaconTransportP2PMatrix (3.1.0):
+    - BeaconCore (~> 3.1.0)
+  - BigInt (5.0.0)
   - Flutter (1.0.0)
+  - Sodium (0.9.1)
 
 DEPENDENCIES:
   - beacondart (from `.symlinks/plugins/beacondart/ios`)
   - Flutter (from `Flutter`)
+
+SPEC REPOS:
+  trunk:
+    - Base58Swift
+    - BeaconBlockchainSubstrate
+    - BeaconBlockchainTezos
+    - BeaconClientWallet
+    - BeaconCore
+    - BeaconTransportP2PMatrix
+    - BigInt
+    - Sodium
 
 EXTERNAL SOURCES:
   beacondart:
@@ -14,9 +45,17 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  beacondart: 15ef76ec1ec5235d9a620704150a1ccbde740a97
+  Base58Swift: 53d551f0b33d9478fa63b3445e453a772d6b31a7
+  BeaconBlockchainSubstrate: 756559d26194cec7a0fa3a5c154b144481346da6
+  BeaconBlockchainTezos: cec3acbffee93de39cf65a48a71a80107b5f54c2
+  BeaconClientWallet: 1ace31cc9b248ac97a3b6016675f93059a8d8bd3
+  BeaconCore: 16619de3b08d533406c13ed6d5339ed9b68b4498
+  beacondart: 06b6a99d11ddf12096fbbed6fec09a4a807b987f
+  BeaconTransportP2PMatrix: 78b3e0b490c5bd9584c7e0ae9e925b1bba8b1720
+  BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
 
-PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
+PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
 COCOAPODS: 1.11.2

--- a/ios/beacondart.podspec
+++ b/ios/beacondart.podspec
@@ -15,7 +15,12 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '12.0'
+  s.dependency 'BeaconCore'
+  s.dependency 'BeaconClientWallet'
+  s.dependency 'BeaconBlockchainSubstrate'
+  s.dependency 'BeaconBlockchainTezos'
+  s.dependency 'BeaconTransportP2PMatrix'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
since the beaconcore and dependencies weren't deployed to cocopod, @jayluxferro deployed to cocopod using the original repo https://github.com/airgap-it/beacon-ios-sdk .